### PR TITLE
Add jwoudenberg/rvn to list of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Build **roc cli && language server** `cargo build -p roc_cli --release && cargo 
 - [mulias/roc-array2d](https://github.com/mulias/roc-array2d) 2D Arrays
 - [shritesh/roc-image](https://github.com/shritesh/roc-image): Image library with PNG export.
 - [Subtlesplendor/roc-data](https://github.com/Subtlesplendor/roc-data): Useful types like Stack, Queue, Bag
+- [jwoudenberg/rvn](https://github.com/jwoudenberg/rvn): A serialization format based on Roc syntax.
 
 *Work In Progress*
 - 🚧 [roc-lang/unicode](https://github.com/roc-lang/unicode): Unicode


### PR DESCRIPTION
This PR adds jwoudenberg/rvn to the list of packages.

There's still a couple of things that would be nice to add, but even without them I think this is useful, so I added it to the 'packages' section instead of the 'work in progress one'. Happy to move it though!