### PR TITLE
Add Weaver library

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Build **roc cli && language server** `cargo build -p roc_cli --release && cargo 
 - [lukewilliamboswell/roc-json](https://github.com/lukewilliamboswell/roc-json): JSON  
 - [lukewilliamboswell/roc-parser](https://github.com/lukewilliamboswell/roc-parser): Parser  
 - [lukewilliamboswell/roc-ansi](https://github.com/lukewilliamboswell/roc-ansi) TUI, Colors and Helpers
+- [smores56/weaver](https://github.com/smores56/weaver) Ergonomic CLI arg parser using `: <-` builder syntax
 - [mulias/roc-array2d](https://github.com/mulias/roc-array2d) 2D Arrays
 - [shritesh/roc-image](https://github.com/shritesh/roc-image): Image library with PNG export.
 - [Subtlesplendor/roc-data](https://github.com/Subtlesplendor/roc-data): Useful types like Stack, Queue, Bag


### PR DESCRIPTION
Add the new [Weaver](https://github.com/smores56/weaver) library to the README.

I considered making a different section of the README for terminal libraries, but I didn't know how to go about it, so I'll save that for a later PR to avoid yak shaving this.