### PR TITLE
Add roc-semver to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Some of the links below are 🚧 **Work In Progress** 🚧 so please keep this i
 - [lukewilliamboswell/roc-ansi](https://github.com/lukewilliamboswell/roc-ansi) Helpers for pretty Terminal UI, ANSI Codes, Colors
 - [lukewilliamboswell/roc-glue-code-gen](https://github.com/lukewilliamboswell/roc-glue-code-gen): Hlpers for generating roc glue
 - [smores56/weaver](https://github.com/smores56/weaver) Ergonomic CLI Argument Parsing
+- [smores56/roc-semver](https://github.com/smores56/roc-semver) Semver 2.0.0 parsing and match checking
 - [mulias/roc-array2d](https://github.com/mulias/roc-array2d) 2D Arrays
 - [shritesh/roc-image](https://github.com/shritesh/roc-image): Image library with PNG export.
 - [Subtlesplendor/roc-data](https://github.com/Subtlesplendor/roc-data): Helpful types like Stack, Queue, Bag


### PR DESCRIPTION
I've implemented [semver 2.0.0](https://semver.org) in Roc, adding it to this repo for visibility.